### PR TITLE
Fix FiDTrainer label handling and aux loss bug

### DIFF
--- a/llm_blender/pair_ranker/trainer.py
+++ b/llm_blender/pair_ranker/trainer.py
@@ -40,11 +40,11 @@ class FiDTrainer(Seq2SeqTrainer):
         if self.label_smoother is not None and "labels" in inputs:
             labels = inputs.pop("labels")
         else:
-            labels = None
+            labels = inputs.get("labels")
         outputs = model(
             input_ids=inputs["input_ids"],
             attention_mask=inputs["attention_mask"],
-            labels=inputs["labels"],
+            labels=labels,
         )
 
         # Save past state if it exists
@@ -60,9 +60,9 @@ class FiDTrainer(Seq2SeqTrainer):
 
         if self.model.config.use_aux_loss:
             if isinstance(self.model, torch.nn.parallel.DistributedDataParallel):
-                _, aux_loss = self.model.module.compute_auxiliary_loss(input["scores"])
+                _, aux_loss = self.model.module.compute_auxiliary_loss(inputs["scores"])
             else:
-                _, aux_loss = self.model.compute_auxiliary_loss(input["scores"])
+                _, aux_loss = self.model.compute_auxiliary_loss(inputs["scores"])
             loss += aux_loss
 
         return (loss, outputs) if return_outputs else loss


### PR DESCRIPTION
## Summary
- avoid key error when using label smoothing in FiDTrainer
- compute auxiliary loss with correct input dictionary

## Testing
- `python -m py_compile llm_blender/pair_ranker/trainer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae8a991f7c83328d3bddacd218e412